### PR TITLE
remove min and max function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,6 @@ Swift Sugar is heavily inspired on [ObjectiveSugar](https://github.com/supermari
 ```
 
 ``` swift
-[1,2,3,4].minimum()
-// 1
-```
-
-``` swift
-[1,2,3,4].maximum()
-// 4
-```
-
-``` swift
 [1,2,3,4,1].numberTimesRepeated(1)
 // 2
 ```
@@ -132,6 +122,22 @@ String.join("S","w","i","f","t")
 "Swift programming".reverse()
 //gnimmargorp tfiwS
 ```
+
+### Swift (Global functions)
+---
+
+**Collections**  
+``` swift
+minElement([1,2,3,4])
+// 1
+```
+
+``` swift
+manElement([1,2,3,4])
+//4
+```
+
+
 
 
 

--- a/SwiftSugar/SwiftSugar/ArrayExtensions.swift
+++ b/SwiftSugar/SwiftSugar/ArrayExtensions.swift
@@ -43,34 +43,6 @@ extension Array {
         return Array(self[firstNumberOfElements..<self.count])
     }
     
-    func minimum<U where U : Comparable>()-> U {
-        var minimum = self[0] as U
-        
-        for element in self {
-            let castedElement = element as U
-
-            if castedElement < minimum {
-                minimum = castedElement
-            }
-        }
-        
-        return minimum
-    }
-    
-    func maximum<U where U : Comparable>()-> U {
-        var maximum = self[0] as U
-        
-        for element in self {
-            let castedElement = element as U
-            if castedElement > maximum {
-                maximum = castedElement
-            }
-        }
-        
-        return maximum
-    }
-    
-    
     func numberTimesRepeated<U where U : Equatable>(elementInArray : U)-> Int {
         var repeated : Int = 0
         

--- a/SwiftSugarTests/ArrayExtensionsTests.swift
+++ b/SwiftSugarTests/ArrayExtensionsTests.swift
@@ -35,18 +35,6 @@ class ArrayExtensionsTests: XCTestCase {
         XCTAssertEqual(result[0], 2, "Should be 2")
     }
     
-    func testMinimum (){
-     
-        var minimum : Int = [1,2,3,4,5].minimum()
-        XCTAssertEqual(minimum, 1, "Should be 1")
-    }
-    
-    func testMaximum (){
-        
-        var maximum : Int = [1,2,3,4,5].maximum()
-        XCTAssertEqual(maximum, 5, "Should be 5")
-    }
-    
     func testNumberTimesRepeated (){
         
         var numberTimesRepeated : Int = [1,2,3,4,5].numberTimesRepeated(2)


### PR DESCRIPTION
Use standard  minElement and maxElement functions

If I try to use `maximum` with object that  isn't Comparable it will crash at runtime. There is no type checking
`var maximum : Int = [A(), A()].maximum()` - Crash
`var minimum : Int = minElement([A(), A()])` - compile error
`var minimum : Int = minElement([1,2,3,4,5]` - work perfect 

I was trying to wrap minElement inside minimum. I failed because arrays don't have to store Comparable elements.
I suggest to got for standard `minElement` and `manElement`